### PR TITLE
MSLO available when super weapons are off; TMPL unavailable when super weapons are off.

### DIFF
--- a/mods/ca/rules/structures.yaml
+++ b/mods/ca/rules/structures.yaml
@@ -11,7 +11,7 @@ MSLO:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 140
-		Prerequisites: techcenter, ~techlevel.unrestricted
+		Prerequisites: techcenter, ~techlevel.unrestricted, ~techlevel.superw
 		BuildLimit: 1
 		Description: Provides an atomic bomb.\nRequires power to operate.\nMaximum 1 can be built.\n  Special Ability: Atom Bomb
 	Building:
@@ -4052,7 +4052,7 @@ TMPL:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 140
-		Prerequisites: hq, ~structures.nod, ~techlevel.superw
+		Prerequisites: hq, ~structures.nod
 		IconPalette: chrometd
 		Description: Provides Nod advanced technologies.\nRequires power to operate.\n  Special Ability: Neutron Bomb
 	Building:


### PR DESCRIPTION
I wasn't sure if you took change requests for your mod; so close this if you don't.

I corrected what is possibly an issue with the missile silo being available when super weapons were disabled (I'm not sure if you intended for this or not).

I also corrected the Temple of NOD being disabled when super weapons were off, which would disallow any buildings/units requiring the temple from being built by NOD players. You already had a prerequisites line for the temple's super weapon so the super weapon remains properly disabled.